### PR TITLE
Add WPF desktop client skeleton with Telerik UI timeline

### DIFF
--- a/desktop/Cui.Desktop/App.xaml
+++ b/desktop/Cui.Desktop/App.xaml
@@ -1,0 +1,13 @@
+<Application x:Class="Cui.Desktop.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:telerik="http://schemas.telerik.com/2008/xaml/presentation"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <telerik:FluentTheme/> 
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/desktop/Cui.Desktop/App.xaml.cs
+++ b/desktop/Cui.Desktop/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace Cui.Desktop;
+
+public partial class App : Application
+{
+}

--- a/desktop/Cui.Desktop/Cui.Desktop.csproj
+++ b/desktop/Cui.Desktop/Cui.Desktop.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="SampleData/SampleConversation.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/desktop/Cui.Desktop/MainWindow.xaml
+++ b/desktop/Cui.Desktop/MainWindow.xaml
@@ -1,0 +1,145 @@
+<Window x:Class="Cui.Desktop.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:telerik="http://schemas.telerik.com/2008/xaml/presentation"
+        xmlns:viewModels="clr-namespace:Cui.Desktop.ViewModels"
+        xmlns:selectors="clr-namespace:Cui.Desktop.Selectors"
+        xmlns:controls="clr-namespace:Cui.Desktop.Views.Controls"
+        mc:Ignorable="d"
+        Title="Common Agent UI" Height="900" Width="1400">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+
+        <DataTemplate x:Key="UserMessageTemplate" DataType="{x:Type viewModels:MessageGroupViewModel}">
+            <Border Margin="0,8" Background="#FFEEF7FF" BorderBrush="#FFB7D4F6" BorderThickness="1" CornerRadius="8" Padding="12" HorizontalAlignment="Right" MaxWidth="520">
+                <StackPanel>
+                    <TextBlock Text="{Binding PreviewText}" TextWrapping="Wrap" />
+                    <ContentControl Content="{Binding RemainingText}" Margin="0,8,0,0">
+                        <ContentControl.Style>
+                            <Style TargetType="ContentControl">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsExpanded}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ContentControl.Style>
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}" TextWrapping="Wrap" />
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
+                    <telerik:RadButton Content="{Binding ExpandLabel}"
+                                        Command="{Binding ToggleExpandCommand}"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,8,0,0"
+                                        Visibility="{Binding HasOverflowText, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate x:Key="AssistantMessageTemplate" DataType="{x:Type viewModels:MessageGroupViewModel}">
+            <Grid Margin="0,8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="36" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <Grid Grid.Column="0" Margin="0,8,16,0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Ellipse Width="12" Height="12" Fill="#FF4C8BF5" HorizontalAlignment="Center" />
+                    <Rectangle Grid.Row="1" Width="2" Fill="#FFE0E0E0" HorizontalAlignment="Center" />
+                </Grid>
+                <Border Grid.Column="1" Background="#FFFFFFFF" BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="8" Padding="12">
+                    <ItemsControl ItemsSource="{Binding AssistantBlocks}" Margin="0">
+                        <ItemsControl.Resources>
+                            <DataTemplate DataType="{x:Type viewModels:TextBlockViewModel}">
+                                <telerik:RadMarkdownViewer Margin="0,0,0,12" Markdown="{Binding Markdown}" />
+                            </DataTemplate>
+                            <DataTemplate DataType="{x:Type viewModels:ThinkingBlockViewModel}">
+                                <telerik:RadMarkdownViewer Margin="0,0,0,12" Markdown="{Binding Markdown}" Foreground="Gray" FontStyle="Italic" />
+                            </DataTemplate>
+                            <DataTemplate DataType="{x:Type viewModels:JsonBlockViewModel}">
+                                <Border Margin="0,0,0,12" BorderBrush="#FFD0D0D0" BorderThickness="1" Padding="8" Background="#FFF9F9F9">
+                                    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" MaxHeight="220">
+                                        <TextBox Text="{Binding Json}" FontFamily="Consolas" IsReadOnly="True" BorderThickness="0" TextWrapping="Wrap" />
+                                    </ScrollViewer>
+                                </Border>
+                            </DataTemplate>
+                            <DataTemplate DataType="{x:Type viewModels:ToolUseBlockViewModel}">
+                                <controls:ToolContentControl DataContext="{Binding Invocation}" Margin="0,0,0,12" />
+                            </DataTemplate>
+                        </ItemsControl.Resources>
+                    </ItemsControl>
+                </Border>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="ErrorMessageTemplate" DataType="{x:Type viewModels:MessageGroupViewModel}">
+            <Border Margin="0,8" Background="#FFFFEAEA" BorderBrush="#FFE0A0A0" BorderThickness="1" CornerRadius="8" Padding="12" MaxWidth="520">
+                <StackPanel>
+                    <TextBlock Text="{Binding CombinedUserText}" TextWrapping="Wrap" Foreground="#FFB00000" />
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+
+        <selectors:MessageTemplateSelector x:Key="MessageTemplateSelector"
+                                           UserTemplate="{StaticResource UserMessageTemplate}"
+                                           AssistantTemplate="{StaticResource AssistantMessageTemplate}"
+                                           ErrorTemplate="{StaticResource ErrorMessageTemplate}" />
+    </Window.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0" Background="#FF1F2937" Padding="16">
+            <DockPanel>
+                <TextBlock Text="Common Agent UI" Foreground="White" FontSize="20" FontWeight="SemiBold" DockPanel.Dock="Left" />
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                    <telerik:RadButton Content="加载示例会话" Command="{Binding LoadSampleConversationCommand}" />
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <telerik:RadListView Grid.Row="1"
+                             ItemsSource="{Binding Messages}"
+                             ItemTemplateSelector="{StaticResource MessageTemplateSelector}"
+                             SelectionMode="Single"
+                             IsSynchronizedWithCurrentItem="False"
+                             SelectionChanged="RadListView_SelectionChanged"
+                             Background="#FFF5F6F8"
+                             BorderThickness="0"
+                             Margin="0"
+                             IsScrollingEnabled="True" />
+
+        <Border Grid.Row="2" Padding="12" Background="#FFF5F6F8" BorderThickness="0,1,0,0" BorderBrush="#FFE0E0E0">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Visibility="{Binding ShowStreamingIndicator, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Ellipse Width="10" Height="10" Fill="#FF4C8BF5">
+                    <Ellipse.Triggers>
+                        <EventTrigger RoutedEvent="Loaded">
+                            <BeginStoryboard>
+                                <Storyboard RepeatBehavior="Forever" AutoReverse="True">
+                                    <DoubleAnimation Storyboard.TargetProperty="Opacity" From="1" To="0.2" Duration="0:0:0.6" />
+                                </Storyboard>
+                            </BeginStoryboard>
+                        </EventTrigger>
+                    </Ellipse.Triggers>
+                </Ellipse>
+                <TextBlock Text="助手正在思考..." Foreground="#FF4C4C4C" Margin="8,0,0,0" />
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/desktop/Cui.Desktop/MainWindow.xaml.cs
+++ b/desktop/Cui.Desktop/MainWindow.xaml.cs
@@ -1,0 +1,31 @@
+using System.Windows;
+using Cui.Desktop.ViewModels;
+using Telerik.Windows.Controls;
+
+namespace Cui.Desktop;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+        DataContext = new MainViewModel();
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is MainViewModel viewModel)
+        {
+            viewModel.LoadSampleConversation();
+        }
+    }
+
+    private void RadListView_SelectionChanged(object sender, SelectionChangeEventArgs e)
+    {
+        if (sender is RadListView listView)
+        {
+            listView.SelectedItems.Clear();
+        }
+    }
+}

--- a/desktop/Cui.Desktop/Models/ChatMessage.cs
+++ b/desktop/Cui.Desktop/Models/ChatMessage.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+
+namespace Cui.Desktop.Models;
+
+public enum ChatMessageType
+{
+    User,
+    Assistant,
+    Error,
+    System
+}
+
+public sealed class ChatMessage
+{
+    public ChatMessageType Type { get; init; }
+    public DateTimeOffset Timestamp { get; init; }
+    public string? WorkingDirectory { get; init; }
+    public string? Text { get; init; }
+    public IList<MessageContentBlock> Blocks { get; init; } = new List<MessageContentBlock>();
+}
+
+public abstract class MessageContentBlock
+{
+    protected MessageContentBlock(ContentBlockType blockType)
+    {
+        BlockType = blockType;
+    }
+
+    public ContentBlockType BlockType { get; }
+}
+
+public enum ContentBlockType
+{
+    Text,
+    Thinking,
+    ToolUse,
+    Json
+}
+
+public sealed class TextContentBlock : MessageContentBlock
+{
+    public TextContentBlock(string markdown)
+        : base(ContentBlockType.Text)
+    {
+        Markdown = markdown;
+    }
+
+    public string Markdown { get; }
+}
+
+public sealed class ThinkingContentBlock : MessageContentBlock
+{
+    public ThinkingContentBlock(string markdown)
+        : base(ContentBlockType.Thinking)
+    {
+        Markdown = markdown;
+    }
+
+    public string Markdown { get; }
+}
+
+public sealed class JsonContentBlock : MessageContentBlock
+{
+    public JsonContentBlock(string json)
+        : base(ContentBlockType.Json)
+    {
+        Json = json;
+    }
+
+    public string Json { get; }
+}
+
+public sealed class ToolUseContentBlock : MessageContentBlock
+{
+    public ToolUseContentBlock(ToolInvocation invocation)
+        : base(ContentBlockType.ToolUse)
+    {
+        Invocation = invocation;
+    }
+
+    public ToolInvocation Invocation { get; }
+}

--- a/desktop/Cui.Desktop/Models/ToolInvocation.cs
+++ b/desktop/Cui.Desktop/Models/ToolInvocation.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+
+namespace Cui.Desktop.Models;
+
+public sealed class ToolInvocation
+{
+    public string ToolName { get; init; } = string.Empty;
+    public string? DisplayName { get; init; }
+    public IDictionary<string, object?> Arguments { get; init; } = new Dictionary<string, object?>();
+    public ToolResult Result { get; init; } = ToolResult.Pending();
+}
+
+public enum ToolExecutionStatus
+{
+    Pending,
+    Completed
+}
+
+public sealed class ToolResult
+{
+    private ToolResult(ToolExecutionStatus status)
+    {
+        Status = status;
+    }
+
+    public ToolExecutionStatus Status { get; }
+    public bool IsError { get; init; }
+    public string? Output { get; init; }
+    public string? ErrorMessage { get; init; }
+    public IReadOnlyList<ChatMessage> ChildMessages { get; init; } = Array.Empty<ChatMessage>();
+    public DateTimeOffset? CompletedAt { get; init; }
+
+    public static ToolResult Pending() => new(ToolExecutionStatus.Pending);
+
+    public static ToolResult Completed(string? output = null, bool isError = false, string? errorMessage = null, IEnumerable<ChatMessage>? children = null)
+    {
+        return new ToolResult(ToolExecutionStatus.Completed)
+        {
+            Output = output,
+            IsError = isError,
+            ErrorMessage = errorMessage,
+            ChildMessages = children is null ? Array.Empty<ChatMessage>() : new List<ChatMessage>(children),
+            CompletedAt = DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/desktop/Cui.Desktop/SampleData/SampleConversation.json
+++ b/desktop/Cui.Desktop/SampleData/SampleConversation.json
@@ -1,0 +1,37 @@
+{
+  "messages": [
+    {
+      "type": "user",
+      "text": "请帮我查看项目简介，并总结核心能力。"
+    },
+    {
+      "type": "assistant",
+      "blocks": [
+        { "type": "thinking", "text": "正在查找 docs/overview.md 以了解项目背景。" },
+        {
+          "type": "tool_use",
+          "toolName": "read",
+          "displayName": "读取文件",
+          "arguments": { "path": "docs/overview.md" },
+          "result": { "status": "pending" }
+        }
+      ]
+    },
+    {
+      "type": "assistant",
+      "blocks": [
+        {
+          "type": "tool_use",
+          "toolName": "read",
+          "displayName": "读取文件",
+          "arguments": { "path": "docs/overview.md" },
+          "result": {
+            "status": "completed",
+            "output": "# Common Agent UI\n- 支持多模型\n- 浏览器实时监控"
+          }
+        },
+        { "type": "text", "text": "我已读取项目概览，接下来会给出总结。" }
+      ]
+    }
+  ]
+}

--- a/desktop/Cui.Desktop/Selectors/MessageTemplateSelector.cs
+++ b/desktop/Cui.Desktop/Selectors/MessageTemplateSelector.cs
@@ -1,0 +1,28 @@
+using System.Windows;
+using System.Windows.Controls;
+using Cui.Desktop.ViewModels;
+
+namespace Cui.Desktop.Selectors;
+
+public sealed class MessageTemplateSelector : DataTemplateSelector
+{
+    public DataTemplate? UserTemplate { get; set; }
+    public DataTemplate? AssistantTemplate { get; set; }
+    public DataTemplate? ErrorTemplate { get; set; }
+
+    public override DataTemplate? SelectTemplate(object item, DependencyObject container)
+    {
+        if (item is not MessageGroupViewModel message)
+        {
+            return base.SelectTemplate(item, container);
+        }
+
+        return message.MessageType switch
+        {
+            Models.ChatMessageType.User => UserTemplate,
+            Models.ChatMessageType.Assistant => AssistantTemplate,
+            Models.ChatMessageType.Error => ErrorTemplate,
+            _ => base.SelectTemplate(item, container)
+        };
+    }
+}

--- a/desktop/Cui.Desktop/Selectors/ToolContentTemplateSelector.cs
+++ b/desktop/Cui.Desktop/Selectors/ToolContentTemplateSelector.cs
@@ -1,0 +1,29 @@
+using System.Windows;
+using System.Windows.Controls;
+using Cui.Desktop.ViewModels;
+
+namespace Cui.Desktop.Selectors;
+
+public sealed class ToolContentTemplateSelector : DataTemplateSelector
+{
+    public DataTemplate? ReadTemplate { get; set; }
+    public DataTemplate? EditTemplate { get; set; }
+    public DataTemplate? TaskTemplate { get; set; }
+    public DataTemplate? GenericTemplate { get; set; }
+
+    public override DataTemplate? SelectTemplate(object item, DependencyObject container)
+    {
+        if (item is not ToolContentViewModel content)
+        {
+            return base.SelectTemplate(item, container);
+        }
+
+        return content switch
+        {
+            ReadToolContentViewModel => ReadTemplate,
+            EditToolContentViewModel => EditTemplate,
+            TaskToolContentViewModel => TaskTemplate,
+            _ => GenericTemplate
+        };
+    }
+}

--- a/desktop/Cui.Desktop/Services/IConversationDataSource.cs
+++ b/desktop/Cui.Desktop/Services/IConversationDataSource.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Cui.Desktop.Models;
+
+namespace Cui.Desktop.Services;
+
+public interface IConversationDataSource
+{
+    Task<IEnumerable<ChatMessage>> GetConversationAsync();
+}

--- a/desktop/Cui.Desktop/Services/SampleDataService.cs
+++ b/desktop/Cui.Desktop/Services/SampleDataService.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Cui.Desktop.Models;
+
+namespace Cui.Desktop.Services;
+
+public sealed class SampleDataService : IConversationDataSource
+{
+    public Task<IEnumerable<ChatMessage>> GetConversationAsync()
+    {
+        var now = DateTimeOffset.Now;
+        var messages = new List<ChatMessage>
+        {
+            new()
+            {
+                Type = ChatMessageType.User,
+                Timestamp = now,
+                Text = "请帮我查看项目简介，并总结核心能力。"
+            },
+            new()
+            {
+                Type = ChatMessageType.Assistant,
+                Timestamp = now.AddSeconds(2),
+                Blocks =
+                {
+                    new ThinkingContentBlock("正在查找 docs/overview.md 以了解项目背景。"),
+                    new ToolUseContentBlock(new ToolInvocation
+                    {
+                        ToolName = "read",
+                        DisplayName = "读取文件",
+                        Arguments = new Dictionary<string, object?>
+                        {
+                            { "path", "docs/overview.md" }
+                        },
+                        Result = ToolResult.Pending()
+                    })
+                }
+            },
+            new()
+            {
+                Type = ChatMessageType.Assistant,
+                Timestamp = now.AddSeconds(5),
+                Blocks =
+                {
+                    new ToolUseContentBlock(new ToolInvocation
+                    {
+                        ToolName = "read",
+                        DisplayName = "读取文件",
+                        Arguments = new Dictionary<string, object?>
+                        {
+                            { "path", "docs/overview.md" }
+                        },
+                        Result = ToolResult.Completed(output: "# Common Agent UI\n- 支持多模型\n- 浏览器实时监控")
+                    }),
+                    new TextContentBlock("我已读取项目概览，接下来会给出总结。")
+                }
+            },
+            new()
+            {
+                Type = ChatMessageType.Assistant,
+                Timestamp = now.AddSeconds(8),
+                Blocks =
+                {
+                    new TextContentBlock("**核心能力**\n1. 多任务并行\n2. 多模型路由\n3. 推送与语音辅助")
+                }
+            },
+            new()
+            {
+                Type = ChatMessageType.User,
+                Timestamp = now.AddSeconds(12),
+                Text = "继续梳理一下任务执行流程。"
+            },
+            new()
+            {
+                Type = ChatMessageType.Assistant,
+                Timestamp = now.AddSeconds(14),
+                Blocks =
+                {
+                    new ToolUseContentBlock(new ToolInvocation
+                    {
+                        ToolName = "task",
+                        DisplayName = "执行子任务",
+                        Arguments = new Dictionary<string, object?>
+                        {
+                            { "title", "梳理任务流程" }
+                        },
+                        Result = ToolResult.Completed(children: new[]
+                        {
+                            new ChatMessage
+                            {
+                                Type = ChatMessageType.Assistant,
+                                Timestamp = now.AddSeconds(15),
+                                Blocks =
+                                {
+                                    new TextContentBlock("调度器启动后台任务")
+                                }
+                            },
+                            new ChatMessage
+                            {
+                                Type = ChatMessageType.Assistant,
+                                Timestamp = now.AddSeconds(16),
+                                Blocks =
+                                {
+                                    new TextContentBlock("实时推送状态到前端时间线")
+                                }
+                            }
+                        })
+                    }),
+                    new ThinkingContentBlock("整理子任务结果，准备总结。")
+                }
+            },
+            new()
+            {
+                Type = ChatMessageType.Assistant,
+                Timestamp = now.AddSeconds(18),
+                Blocks =
+                {
+                    new TextContentBlock("任务流程包括调度、执行与通知三个阶段。")
+                }
+            },
+            new()
+            {
+                Type = ChatMessageType.Assistant,
+                Timestamp = now.AddSeconds(20),
+                Blocks =
+                {
+                    new ToolUseContentBlock(new ToolInvocation
+                    {
+                        ToolName = "edit",
+                        DisplayName = "更新文档",
+                        Arguments = new Dictionary<string, object?>
+                        {
+                            { "path", "docs/overview.md" }
+                        },
+                        Result = ToolResult.Completed(isError: true, errorMessage: "文件被锁定，无法写入。")
+                    })
+                }
+            },
+            new()
+            {
+                Type = ChatMessageType.Error,
+                Timestamp = now.AddSeconds(21),
+                Text = "更新文档失败：文件被其他进程占用。"
+            }
+        };
+
+        return Task.FromResult<IEnumerable<ChatMessage>>(messages);
+    }
+}

--- a/desktop/Cui.Desktop/ViewModels/AssistantBlocks.cs
+++ b/desktop/Cui.Desktop/ViewModels/AssistantBlocks.cs
@@ -1,0 +1,57 @@
+using Cui.Desktop.Models;
+
+namespace Cui.Desktop.ViewModels;
+
+public abstract class AssistantBlockViewModel : ViewModelBase
+{
+    protected AssistantBlockViewModel(MessageContentBlock source)
+    {
+        Source = source;
+    }
+
+    public MessageContentBlock Source { get; }
+}
+
+public sealed class TextBlockViewModel : AssistantBlockViewModel
+{
+    public TextBlockViewModel(TextContentBlock block)
+        : base(block)
+    {
+        Markdown = block.Markdown;
+    }
+
+    public string Markdown { get; }
+}
+
+public sealed class ThinkingBlockViewModel : AssistantBlockViewModel
+{
+    public ThinkingBlockViewModel(ThinkingContentBlock block)
+        : base(block)
+    {
+        Markdown = block.Markdown;
+    }
+
+    public string Markdown { get; }
+}
+
+public sealed class JsonBlockViewModel : AssistantBlockViewModel
+{
+    public JsonBlockViewModel(JsonContentBlock block)
+        : base(block)
+    {
+        Json = block.Json;
+    }
+
+    public string Json { get; }
+}
+
+public sealed class ToolUseBlockViewModel : AssistantBlockViewModel
+{
+    public ToolUseBlockViewModel(ToolUseContentBlock block, ToolInvocationViewModel invocation)
+        : base(block)
+    {
+        Invocation = invocation;
+    }
+
+    public ToolInvocationViewModel Invocation { get; }
+}

--- a/desktop/Cui.Desktop/ViewModels/MainViewModel.cs
+++ b/desktop/Cui.Desktop/ViewModels/MainViewModel.cs
@@ -1,0 +1,157 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using Cui.Desktop.Models;
+using Cui.Desktop.Services;
+
+namespace Cui.Desktop.ViewModels;
+
+public sealed class MainViewModel : ViewModelBase
+{
+    private readonly IConversationDataSource _dataSource;
+    private bool _isStreaming;
+    private bool _hasPendingToolResults;
+
+    public MainViewModel()
+        : this(new SampleDataService())
+    {
+    }
+
+    public MainViewModel(IConversationDataSource dataSource)
+    {
+        _dataSource = dataSource;
+        LoadSampleConversationCommand = new RelayCommand(LoadSampleConversation);
+        Messages.CollectionChanged += OnMessagesCollectionChanged;
+    }
+
+    public ObservableCollection<MessageGroupViewModel> Messages { get; } = new();
+
+    public bool IsStreaming
+    {
+        get => _isStreaming;
+        private set
+        {
+            if (SetProperty(ref _isStreaming, value))
+            {
+                RaisePropertyChanged(nameof(ShowStreamingIndicator));
+            }
+        }
+    }
+
+    public bool HasPendingToolResults
+    {
+        get => _hasPendingToolResults;
+        private set
+        {
+            if (SetProperty(ref _hasPendingToolResults, value))
+            {
+                RaisePropertyChanged(nameof(ShowStreamingIndicator));
+            }
+        }
+    }
+
+    public bool ShowStreamingIndicator => IsStreaming && !HasPendingToolResults;
+
+    public RelayCommand LoadSampleConversationCommand { get; }
+
+    public async void LoadSampleConversation()
+    {
+        IsStreaming = true;
+        try
+        {
+            var conversation = await _dataSource.GetConversationAsync();
+            LoadConversation(conversation);
+        }
+        finally
+        {
+            IsStreaming = false;
+        }
+    }
+
+    public void LoadConversation(IEnumerable<ChatMessage> rawMessages)
+    {
+        foreach (var group in Messages.ToList())
+        {
+            group.PropertyChanged -= OnMessageGroupPropertyChanged;
+        }
+
+        Messages.Clear();
+        MessageGroupViewModel? current = null;
+
+        foreach (var message in FilterMessages(rawMessages))
+        {
+            if (current is null || current.MessageType != message.Type)
+            {
+                current = MessageGroupViewModel.FromMessage(message);
+                Messages.Add(current);
+            }
+            else
+            {
+                current.Append(message);
+            }
+        }
+
+        UpdatePendingToolFlag();
+    }
+
+    public void UpdateStreamingState(bool isStreaming)
+    {
+        IsStreaming = isStreaming;
+        UpdatePendingToolFlag();
+    }
+
+    private IEnumerable<ChatMessage> FilterMessages(IEnumerable<ChatMessage> messages)
+    {
+        foreach (var message in messages)
+        {
+            if (message.Type == ChatMessageType.User && message.Blocks.Count > 0 && message.Blocks.All(block => block is ToolUseContentBlock))
+            {
+                continue;
+            }
+
+            yield return message;
+        }
+    }
+
+    private void UpdatePendingToolFlag()
+    {
+        HasPendingToolResults = Messages.Any(group => group.HasPendingToolResult);
+    }
+
+    private void OnMessagesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.NewItems is not null)
+        {
+            foreach (var item in e.NewItems)
+            {
+                if (item is MessageGroupViewModel group)
+                {
+                    group.PropertyChanged += OnMessageGroupPropertyChanged;
+                }
+            }
+        }
+
+        if (e.OldItems is not null)
+        {
+            foreach (var item in e.OldItems)
+            {
+                if (item is MessageGroupViewModel group)
+                {
+                    group.PropertyChanged -= OnMessageGroupPropertyChanged;
+                }
+            }
+        }
+
+        UpdatePendingToolFlag();
+    }
+
+    private void OnMessageGroupPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(MessageGroupViewModel.HasPendingToolResult))
+        {
+            UpdatePendingToolFlag();
+        }
+    }
+}

--- a/desktop/Cui.Desktop/ViewModels/MessageGroupViewModel.cs
+++ b/desktop/Cui.Desktop/ViewModels/MessageGroupViewModel.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using Cui.Desktop.Models;
+
+namespace Cui.Desktop.ViewModels;
+
+public sealed class MessageGroupViewModel : ViewModelBase
+{
+    private readonly List<ChatMessage> _messages = new();
+    private readonly ObservableCollection<AssistantBlockViewModel> _assistantBlocks = new();
+    private readonly RelayCommand _toggleExpandCommand;
+    private bool _isExpanded;
+    private string _combinedUserText = string.Empty;
+    private string _previewText = string.Empty;
+    private string _remainingText = string.Empty;
+
+    private MessageGroupViewModel(ChatMessageType messageType)
+    {
+        MessageType = messageType;
+        _toggleExpandCommand = new RelayCommand(() => IsExpanded = !IsExpanded, () => HasOverflowText);
+    }
+
+    public ChatMessageType MessageType { get; }
+    public IReadOnlyList<ChatMessage> Messages => _messages;
+    public ObservableCollection<AssistantBlockViewModel> AssistantBlocks => _assistantBlocks;
+
+    public bool IsExpanded
+    {
+        get => _isExpanded;
+        set
+        {
+            if (SetProperty(ref _isExpanded, value))
+            {
+                RaisePropertyChanged(nameof(ExpandLabel));
+            }
+        }
+    }
+
+    public string CombinedUserText
+    {
+        get => _combinedUserText;
+        private set => SetProperty(ref _combinedUserText, value);
+    }
+
+    public string PreviewText
+    {
+        get => _previewText;
+        private set => SetProperty(ref _previewText, value);
+    }
+
+    public string RemainingText
+    {
+        get => _remainingText;
+        private set
+        {
+            if (SetProperty(ref _remainingText, value))
+            {
+                RaisePropertyChanged(nameof(HasOverflowText));
+                _toggleExpandCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public bool HasOverflowText => !string.IsNullOrWhiteSpace(RemainingText);
+    public string ExpandLabel => IsExpanded ? "收起" : "展开剩余";
+    public RelayCommand ToggleExpandCommand => _toggleExpandCommand;
+
+    public bool HasPendingToolResult => AssistantBlocks.OfType<ToolUseBlockViewModel>().Any(block => block.Invocation.Result.IsPending);
+
+    public static MessageGroupViewModel FromMessage(ChatMessage message)
+    {
+        var viewModel = new MessageGroupViewModel(message.Type);
+        viewModel.Append(message);
+        return viewModel;
+    }
+
+    public void Append(ChatMessage message)
+    {
+        _messages.Add(message);
+
+        switch (MessageType)
+        {
+            case ChatMessageType.User:
+                AppendUserMessage(message);
+                break;
+            case ChatMessageType.Assistant:
+                AppendAssistantMessage(message);
+                break;
+            case ChatMessageType.Error:
+                AppendErrorMessage(message);
+                break;
+        }
+    }
+
+    private void AppendUserMessage(ChatMessage message)
+    {
+        if (!string.IsNullOrWhiteSpace(message.Text))
+        {
+            if (CombinedUserText.Length > 0)
+            {
+                CombinedUserText += "\n\n";
+            }
+
+            CombinedUserText += message.Text;
+        }
+
+        CalculateUserPreview();
+    }
+
+    private void CalculateUserPreview()
+    {
+        var lines = CombinedUserText.Split(['\n'], StringSplitOptions.None);
+        if (lines.Length <= 8)
+        {
+            PreviewText = CombinedUserText;
+            RemainingText = string.Empty;
+            return;
+        }
+
+        PreviewText = string.Join("\n", lines.Take(8));
+        RemainingText = string.Join("\n", lines.Skip(8));
+    }
+
+    private void AppendAssistantMessage(ChatMessage message)
+    {
+        foreach (var block in message.Blocks)
+        {
+            switch (block)
+            {
+                case TextContentBlock text:
+                    AssistantBlocks.Add(new TextBlockViewModel(text));
+                    break;
+                case ThinkingContentBlock thinking:
+                    AssistantBlocks.Add(new ThinkingBlockViewModel(thinking));
+                    break;
+                case JsonContentBlock json:
+                    AssistantBlocks.Add(new JsonBlockViewModel(json));
+                    break;
+                case ToolUseContentBlock toolUse:
+                    var invocationVm = new ToolInvocationViewModel(toolUse.Invocation);
+                    invocationVm.Synchronize();
+                    invocationVm.Result.PropertyChanged += OnToolResultChanged;
+                    AssistantBlocks.Add(new ToolUseBlockViewModel(toolUse, invocationVm));
+                    RaisePropertyChanged(nameof(HasPendingToolResult));
+                    break;
+            }
+        }
+    }
+
+    private void AppendErrorMessage(ChatMessage message)
+    {
+        if (!string.IsNullOrWhiteSpace(message.Text))
+        {
+            if (CombinedUserText.Length > 0)
+            {
+                CombinedUserText += "\n\n";
+            }
+
+            CombinedUserText += message.Text;
+        }
+    }
+
+    private void OnToolResultChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(ToolResultViewModel.IsPending))
+        {
+            RaisePropertyChanged(nameof(HasPendingToolResult));
+        }
+    }
+}

--- a/desktop/Cui.Desktop/ViewModels/RelayCommand.cs
+++ b/desktop/Cui.Desktop/ViewModels/RelayCommand.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Windows.Input;
+
+namespace Cui.Desktop.ViewModels;
+
+public sealed class RelayCommand : ICommand
+{
+    private readonly Action _execute;
+    private readonly Func<bool>? _canExecute;
+
+    public RelayCommand(Action execute, Func<bool>? canExecute = null)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+
+    public void Execute(object? parameter) => _execute();
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/desktop/Cui.Desktop/ViewModels/ToolInvocationViewModels.cs
+++ b/desktop/Cui.Desktop/ViewModels/ToolInvocationViewModels.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Cui.Desktop.Models;
+
+namespace Cui.Desktop.ViewModels;
+
+public sealed class ToolInvocationViewModel : ViewModelBase
+{
+    private readonly ToolInvocation _invocation;
+
+    public ToolInvocationViewModel(ToolInvocation invocation)
+    {
+        _invocation = invocation;
+        Content = ToolContentViewModelFactory.Create(invocation);
+    }
+
+    public string ToolName => _invocation.ToolName;
+    public string DisplayName => string.IsNullOrWhiteSpace(_invocation.DisplayName) ? _invocation.ToolName : _invocation.DisplayName!;
+    public IReadOnlyDictionary<string, object?> Arguments => new ReadOnlyDictionary<string, object?>(_invocation.Arguments);
+    public ToolResultViewModel Result { get; } = new();
+    public ToolContentViewModel Content { get; }
+
+    public void Synchronize()
+    {
+        Result.Update(_invocation.Result);
+        Content.Synchronize(_invocation);
+    }
+}
+
+public sealed class ToolResultViewModel : ViewModelBase
+{
+    private ToolExecutionStatus _status;
+    private bool _isError;
+    private string? _output;
+    private string? _errorMessage;
+    private IReadOnlyList<ChatMessage> _childMessages = Array.Empty<ChatMessage>();
+
+    public ToolExecutionStatus Status
+    {
+        get => _status;
+        private set => SetProperty(ref _status, value);
+    }
+
+    public bool IsError
+    {
+        get => _isError;
+        private set => SetProperty(ref _isError, value);
+    }
+
+    public string? Output
+    {
+        get => _output;
+        private set => SetProperty(ref _output, value);
+    }
+
+    public string? ErrorMessage
+    {
+        get => _errorMessage;
+        private set => SetProperty(ref _errorMessage, value);
+    }
+
+    public IReadOnlyList<ChatMessage> ChildMessages
+    {
+        get => _childMessages;
+        private set => SetProperty(ref _childMessages, value);
+    }
+
+    public void Update(ToolResult result)
+    {
+        Status = result.Status;
+        IsError = result.IsError;
+        Output = result.Output;
+        ErrorMessage = result.ErrorMessage;
+        ChildMessages = result.ChildMessages;
+        RaisePropertyChanged(nameof(IsPending));
+    }
+
+    public bool IsPending => Status == ToolExecutionStatus.Pending;
+}
+
+public abstract class ToolContentViewModel : ViewModelBase
+{
+    public abstract string IconGlyph { get; }
+    public abstract string Title { get; }
+    public abstract void Synchronize(ToolInvocation invocation);
+}
+
+public sealed class GenericToolContentViewModel : ToolContentViewModel
+{
+    private IReadOnlyDictionary<string, object?> _arguments = new ReadOnlyDictionary<string, object?>(new Dictionary<string, object?>());
+    private string? _output;
+
+    public override string IconGlyph => "\uE80F"; // default icon
+    public override string Title => "工具输出";
+
+    public IReadOnlyDictionary<string, object?> Arguments
+    {
+        get => _arguments;
+        private set => SetProperty(ref _arguments, value);
+    }
+
+    public string? Output
+    {
+        get => _output;
+        private set => SetProperty(ref _output, value);
+    }
+
+    public override void Synchronize(ToolInvocation invocation)
+    {
+        Arguments = new ReadOnlyDictionary<string, object?>(invocation.Arguments);
+        Output = invocation.Result.Output;
+    }
+}
+
+public sealed class ReadToolContentViewModel : ToolContentViewModel
+{
+    private string? _path;
+    private string? _preview;
+
+    public override string IconGlyph => "\uE8A5";
+    public override string Title => "读取文件";
+
+    public string? Path
+    {
+        get => _path;
+        private set => SetProperty(ref _path, value);
+    }
+
+    public string? Preview
+    {
+        get => _preview;
+        private set => SetProperty(ref _preview, value);
+    }
+
+    public override void Synchronize(ToolInvocation invocation)
+    {
+        if (invocation.Arguments.TryGetValue("path", out var value) && value is string str)
+        {
+            Path = str;
+        }
+
+        Preview = invocation.Result.Output;
+    }
+}
+
+public sealed class EditToolContentViewModel : ToolContentViewModel
+{
+    private string? _path;
+    private string? _diff;
+
+    public override string IconGlyph => "\uE104";
+    public override string Title => "修改文件";
+
+    public string? Path
+    {
+        get => _path;
+        private set => SetProperty(ref _path, value);
+    }
+
+    public string? Diff
+    {
+        get => _diff;
+        private set => SetProperty(ref _diff, value);
+    }
+
+    public override void Synchronize(ToolInvocation invocation)
+    {
+        if (invocation.Arguments.TryGetValue("path", out var value) && value is string str)
+        {
+            Path = str;
+        }
+
+        Diff = invocation.Result.Output;
+    }
+}
+
+public sealed class TaskToolContentViewModel : ToolContentViewModel
+{
+    private IReadOnlyList<TaskChildMessageViewModel> _children = Array.Empty<TaskChildMessageViewModel>();
+
+    public override string IconGlyph => "\uE0F3";
+    public override string Title => "子任务";
+
+    public IReadOnlyList<TaskChildMessageViewModel> Children
+    {
+        get => _children;
+        private set => SetProperty(ref _children, value);
+    }
+
+    public override void Synchronize(ToolInvocation invocation)
+    {
+        var list = new List<TaskChildMessageViewModel>();
+        foreach (var message in invocation.Result.ChildMessages)
+        {
+            list.Add(new TaskChildMessageViewModel(message));
+        }
+
+        Children = list;
+    }
+}
+
+public static class ToolContentViewModelFactory
+{
+    public static ToolContentViewModel Create(ToolInvocation invocation)
+    {
+        return invocation.ToolName switch
+        {
+            "read" => new ReadToolContentViewModel(),
+            "edit" => new EditToolContentViewModel(),
+            "task" => new TaskToolContentViewModel(),
+            _ => new GenericToolContentViewModel()
+        };
+    }
+}
+
+public sealed class TaskChildMessageViewModel
+{
+    public TaskChildMessageViewModel(ChatMessage message)
+    {
+        Message = message;
+        Summary = BuildSummary(message);
+    }
+
+    public ChatMessage Message { get; }
+    public string Summary { get; }
+    public DateTimeOffset Timestamp => Message.Timestamp;
+
+    private static string BuildSummary(ChatMessage message)
+    {
+        if (!string.IsNullOrWhiteSpace(message.Text))
+        {
+            return message.Text!;
+        }
+
+        foreach (var block in message.Blocks)
+        {
+            if (block is TextContentBlock text)
+            {
+                return text.Markdown;
+            }
+
+            if (block is ThinkingContentBlock thinking)
+            {
+                return thinking.Markdown;
+            }
+        }
+
+        return "(无内容)";
+    }
+}

--- a/desktop/Cui.Desktop/ViewModels/ViewModelBase.cs
+++ b/desktop/Cui.Desktop/ViewModels/ViewModelBase.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Cui.Desktop.ViewModels;
+
+public abstract class ViewModelBase : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected void RaisePropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    protected bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        RaisePropertyChanged(propertyName);
+        return true;
+    }
+}

--- a/desktop/Cui.Desktop/Views/Controls/ToolContentControl.xaml
+++ b/desktop/Cui.Desktop/Views/Controls/ToolContentControl.xaml
@@ -1,0 +1,115 @@
+<UserControl x:Class="Cui.Desktop.Views.Controls.ToolContentControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:telerik="http://schemas.telerik.com/2008/xaml/presentation"
+             xmlns:viewModels="clr-namespace:Cui.Desktop.ViewModels"
+             xmlns:selectors="clr-namespace:Cui.Desktop.Selectors"
+             x:Name="Root">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+
+        <DataTemplate x:Key="ReadToolTemplate" DataType="{x:Type viewModels:ReadToolContentViewModel}">
+            <StackPanel>
+                <TextBlock Text="文件路径" FontWeight="SemiBold" />
+                <TextBlock Text="{Binding Path}" Margin="0,2,0,8" TextWrapping="Wrap" />
+                <telerik:RadExpander Header="内容预览" IsExpanded="True">
+                    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" MaxHeight="180">
+                        <TextBlock Text="{Binding Preview}" TextWrapping="Wrap" FontFamily="Consolas" />
+                    </ScrollViewer>
+                </telerik:RadExpander>
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate x:Key="EditToolTemplate" DataType="{x:Type viewModels:EditToolContentViewModel}">
+            <StackPanel>
+                <TextBlock Text="目标文件" FontWeight="SemiBold" />
+                <TextBlock Text="{Binding Path}" Margin="0,2,0,8" TextWrapping="Wrap" />
+                <TextBlock Text="修改预览" FontWeight="SemiBold" />
+                <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" MaxHeight="200">
+                    <TextBox Text="{Binding Diff}" IsReadOnly="True" TextWrapping="NoWrap" FontFamily="Consolas" BorderThickness="0" />
+                </ScrollViewer>
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate x:Key="TaskChildTemplate" DataType="{x:Type viewModels:TaskChildMessageViewModel}">
+            <Border Padding="8" Margin="0,4,0,0" Background="#FFF3F3F3" CornerRadius="4">
+                <StackPanel>
+                    <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
+                    <TextBlock Text="{Binding Timestamp, StringFormat='{}{0:HH:mm:ss}'}" FontSize="11" Foreground="Gray" />
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate x:Key="TaskToolTemplate" DataType="{x:Type viewModels:TaskToolContentViewModel}">
+            <StackPanel>
+                <TextBlock Text="子任务明细" FontWeight="SemiBold" />
+                <ItemsControl ItemsSource="{Binding Children}" ItemTemplate="{StaticResource TaskChildTemplate}" />
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate x:Key="GenericToolTemplate" DataType="{x:Type viewModels:GenericToolContentViewModel}">
+            <StackPanel>
+                <TextBlock Text="调用参数" FontWeight="SemiBold" />
+                <ItemsControl ItemsSource="{Binding Arguments}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Grid Margin="0,2,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="160" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="{Binding Key}" FontWeight="SemiBold" />
+                                <TextBlock Grid.Column="1" Text="{Binding Value}" TextWrapping="Wrap" Margin="8,0,0,0" />
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+                <TextBlock Text="结果输出" FontWeight="SemiBold" Margin="0,12,0,0" />
+                <Border BorderBrush="#FFD0D0D0" BorderThickness="1" Padding="8" Background="#FFF9F9F9" Margin="0,4,0,0">
+                    <TextBlock Text="{Binding Output}" TextWrapping="Wrap" />
+                </Border>
+            </StackPanel>
+        </DataTemplate>
+
+        <selectors:ToolContentTemplateSelector x:Key="ToolContentTemplateSelector"
+                                               ReadTemplate="{StaticResource ReadToolTemplate}"
+                                               EditTemplate="{StaticResource EditToolTemplate}"
+                                               TaskTemplate="{StaticResource TaskToolTemplate}"
+                                               GenericTemplate="{StaticResource GenericToolTemplate}" />
+    </UserControl.Resources>
+
+    <Border Padding="12" Background="#FFFFFFFF" CornerRadius="8" BorderBrush="#FFE0E0E0" BorderThickness="1">
+        <StackPanel>
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <Border Width="24" Height="24" CornerRadius="12" Background="#FF4C8BF5">
+                    <TextBlock Text="{Binding Content.IconGlyph}" FontFamily="Segoe MDL2 Assets" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                </Border>
+                <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" VerticalAlignment="Center" Margin="8,0,0,0" />
+                <TextBlock Text="{Binding Result.Status}" Foreground="Gray" VerticalAlignment="Center" Margin="8,0,0,0" />
+                <telerik:RadBusyIndicator Margin="12,0,0,0" IsBusy="{Binding Result.IsPending}" Width="32" Height="32" />
+            </StackPanel>
+
+            <ContentControl Margin="0,12,0,0"
+                            Content="{Binding Content}"
+                            ContentTemplateSelector="{StaticResource ToolContentTemplateSelector}">
+                <ContentControl.Style>
+                    <Style TargetType="ContentControl">
+                        <Setter Property="Visibility" Value="Visible" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Result.IsPending}" Value="True">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ContentControl.Style>
+            </ContentControl>
+
+            <telerik:RadExpander Header="错误详情"
+                                  Margin="0,8,0,0"
+                                  Visibility="{Binding Result.IsError, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                  IsExpanded="False">
+                <TextBlock Text="{Binding Result.ErrorMessage}" TextWrapping="Wrap" Foreground="IndianRed" />
+            </telerik:RadExpander>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/desktop/Cui.Desktop/Views/Controls/ToolContentControl.xaml.cs
+++ b/desktop/Cui.Desktop/Views/Controls/ToolContentControl.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Cui.Desktop.Views.Controls;
+
+public partial class ToolContentControl : UserControl
+{
+    public ToolContentControl()
+    {
+        InitializeComponent();
+    }
+}

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,0 +1,41 @@
+# CUI WPF Desktop Client
+
+该目录包含基于 WPF + Telerik UI 的示例桌面前端，实现了 Common Agent UI 的时间线会话视图。项目核心特性：
+
+- **消息分组与过滤**：自动合并相邻类型的消息，过滤掉仅包含 `tool_result` 的用户消息。
+- **时间线式助手渲染**：助手消息按内容块逐个渲染，支持 Markdown、思考态、工具调用与 JSON 回退。
+- **工具渲染管线**：`ToolContentControl` 按工具类型切换模板，展示文件读取、编辑、任务树及通用参数，并在 pending/error 状态下给出提示。
+- **流式状态指示**：`MainViewModel` 跟踪工具执行与流式输出，底部提供动态指示点。
+- **示例数据服务**：`SampleDataService` 构建示例会话，便于调试。
+
+> ⚠️ 运行该项目需要安装 Telerik UI for WPF，并在本地开发环境中配置对应的 NuGet 源或引用。当前仓库不包含商业依赖。
+
+## 结构
+
+```
+desktop/
+├── Cui.Desktop/              # WPF 项目
+│   ├── Models/               # 消息、工具与内容块模型
+│   ├── ViewModels/           # MVVM 视图模型
+│   ├── Views/Controls/       # 自定义控件（如 ToolContentControl）
+│   ├── Services/             # 示例数据源等服务
+│   ├── Selectors/            # 模板选择器
+│   ├── App.xaml              # 应用入口
+│   └── MainWindow.xaml       # 主界面
+└── README.md
+```
+
+## 运行
+
+1. 在 Windows 环境下安装 .NET 8 SDK，并确保可用 Telerik UI for WPF。
+2. 在 `desktop/Cui.Desktop` 目录执行：
+   ```bash
+   dotnet restore
+   dotnet build
+   ```
+3. 启动应用：
+   ```bash
+   dotnet run
+   ```
+
+应用启动后会自动加载示例会话，也可以通过右上角按钮重新加载数据。


### PR DESCRIPTION
## Summary
- add a new WPF project under `desktop/Cui.Desktop` that models chat messages, tool invocations, and renders grouped timeline views with Telerik controls
- implement view models, data template selectors, and a ToolContentControl to handle text, thinking, tool, and error blocks with pending/error states
- seed the UI with a sample conversation service and document prerequisites for running the desktop client

## Testing
- not run (WPF project requires Windows/Telerik runtime)


------
https://chatgpt.com/codex/tasks/task_e_68c8cd6a7e0c8321a9ab66da32a3f5de